### PR TITLE
Add option to keep space used by tips view if list is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,8 @@ XML attributes can be added to the DropDownList view:
 | attr_primaryTextColor | reference / color | Color for all other elements. Some elements use a faded version of this color e.g. description text |
 | attr_showAllExpanded | boolean | Default false. If true, all tips are shown and the header is hidden. Example in "In-app example" gif as the "Tips" activity |
 
-
+### Kotlin
+Don't remove the space used by the view if the tips list is empty:
+```kotlin
+dropDownList.keepSpaceIfEmpty = true
+```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ XML attributes can be added to the DropDownList view:
 | attr_accentColor | reference / color | Color for number of tips and action button text |
 | attr_primaryTextColor | reference / color | Color for all other elements. Some elements use a faded version of this color e.g. description text |
 | attr_showAllExpanded | boolean | Default false. If true, all tips are shown and the header is hidden. Example in "In-app example" gif as the "Tips" activity |
+| attr_keepSpaceIfEmpty | boolean | Default false. If true, space used by tips view is kept if list is empty |
 
 ### Kotlin
 Don't remove the space used by the view if the tips list is empty:

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,8 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:attr_accentColor="@android:color/holo_blue_dark"
-            app:attr_primaryTextColor="@android:color/black"
-            />
+            app:attr_primaryTextColor="@android:color/black" />
 
         <TextView
             android:layout_width="wrap_content"

--- a/dropdowntipslist/src/main/java/com/tombayley/dropdowntipslist/DropDownList.kt
+++ b/dropdowntipslist/src/main/java/com/tombayley/dropdowntipslist/DropDownList.kt
@@ -43,6 +43,12 @@ class DropDownList(context: Context, attrs: AttributeSet): LinearLayout(context,
     //  - Useful for showing a list of all tips
     protected var showAllExpanded: Boolean = false
 
+    var keepSpaceIfEmpty: Boolean = false
+    set(value) {
+        field = value
+        hideView()
+    }
+
     companion object {
         // Default key return value if an item was not added to the list
         const val ITEM_NOT_ADDED = -1
@@ -50,7 +56,6 @@ class DropDownList(context: Context, attrs: AttributeSet): LinearLayout(context,
 
     init {
         inflate(context, R.layout.drop_down_list, this)
-        visibility = View.GONE
 
         listContainer = findViewById(R.id.list_container)
         arrow = findViewById(R.id.arrow)
@@ -75,7 +80,11 @@ class DropDownList(context: Context, attrs: AttributeSet): LinearLayout(context,
         primaryTextColorFaded = ColorUtil.giveColorAlpha(primaryTextColor, 0.6f)
         accentColor = attributes.getColor(R.styleable.DropDownList_attr_accentColor, Color.BLUE)
         showAllExpanded = attributes.getBoolean(R.styleable.DropDownList_attr_showAllExpanded, false)
+        keepSpaceIfEmpty = attributes.getBoolean(R.styleable.DropDownList_attr_keepSpaceIfEmpty, false)
         attributes.recycle()
+
+        // Hide the drop down list as it is empty
+        hideView()
 
         headerTitlePrefix.setTextColor(primaryTextColor)
         headerTitle.setTextColor(primaryTextColor)
@@ -188,12 +197,16 @@ class DropDownList(context: Context, attrs: AttributeSet): LinearLayout(context,
             headerTitle.text = (listContainer.getChildAt(0).findViewById(R.id.title) as TextView).text
         } else {
             headerTitle.text = ""
-            visibility = View.GONE
+            hideView()
         }
 
         numTips.text = newNumListItems.toString()
 
         if (isExpanded) animateHeightChange(prevHeight, getListMeasuredHeight())
+    }
+
+    protected fun hideView() {
+        visibility = if (keepSpaceIfEmpty) View.INVISIBLE else View.GONE
     }
 
     /**

--- a/dropdowntipslist/src/main/res/values/attrs.xml
+++ b/dropdowntipslist/src/main/res/values/attrs.xml
@@ -7,6 +7,7 @@
         <attr name="attr_primaryTextColor" />
         <attr name="attr_accentColor" />
         <attr name="attr_showAllExpanded" format="boolean"/>
+        <attr name="attr_keepSpaceIfEmpty" format="boolean"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
- `app:attr_keepSpaceIfEmpty="true"`
or
- `dropDownList.keepSpaceIfEmpty = true`